### PR TITLE
Add safebooru.donmai.us to default sites

### DIFF
--- a/docs/source/quick_start_guide.rst
+++ b/docs/source/quick_start_guide.rst
@@ -112,3 +112,4 @@ Pybooru has a list of default sites that allow you to use Pybooru without "site_
 - konachan (`Konachan <http://konachan.com/>`_)
 - yandere (`Yande.re <https://yande.re/post>`_)
 - danbooru (`Danbooru <http://danbooru.donmai.us/>`_)
+- safebooru (`Safebooru <http://safebooru.donmai.us/>`_)

--- a/pybooru/resources.py
+++ b/pybooru/resources.py
@@ -23,6 +23,8 @@ SITE_LIST = {
         'hashed_string': "choujin-steiner--{0}--"},
     'danbooru': {
         'url': "http://danbooru.donmai.us"}
+    'safebooru': {
+        'url': "https://safebooru.donmai.us"}
     }
 
 

--- a/pybooru/resources.py
+++ b/pybooru/resources.py
@@ -22,7 +22,7 @@ SITE_LIST = {
         'api_version': "1.13.0+update.3",
         'hashed_string': "choujin-steiner--{0}--"},
     'danbooru': {
-        'url': "http://danbooru.donmai.us"}
+        'url': "http://danbooru.donmai.us"},
     'safebooru': {
         'url': "https://safebooru.donmai.us"}
     }


### PR DESCRIPTION
Danbooru's domain for results without non-safe posts. It removes the needs to use the `rating:safe` tag for searches (which is problematic because of the two tag limit).