### PR TITLE
Fixes the file url in the download example.

### DIFF
--- a/examples/danbooru/download_example.py
+++ b/examples/danbooru/download_example.py
@@ -17,7 +17,7 @@ def download(tags, pages):
             posts = client.post_list(tags=tags, page=randompage, limit=200)
             for post in posts:
                 try:
-                    fileurl = 'https://danbooru.donmai.us' + post['file_url']
+                    fileurl = post['file_url']
                 except:
                     fileurl = 'https://danbooru.donmai.us' + post['source']
                 x.append(fileurl)


### PR DESCRIPTION
Danbooru's API already includes the host in 'file_url'. This removes the duplicated host at the beginning of the URL.