### PR TITLE
release: Pybooru 4.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Pybooru** is a Python package to access to the API of Danbooru/Moebooru based sites.
 
-- Version: **4.1.0**
+- Version: **4.2.0**
 - Licensed under: **MIT License**
 
 ## Dependencies
@@ -87,7 +87,7 @@ You can consult the documentation on **[Read the Docs](https://pybooru.readthedo
 ## Status
 | Platform       | Master         | Develop |
 | :------------- | :------------- | :------- |
-| [Linux & OSX (Travis CI)](https://travis-ci.org/LuqueDaniel/pybooru) | [![Travis CI](https://travis-ci.org/LuqueDaniel/pybooru.svg?branch=master)](https://travis-ci.org/LuqueDaniel/pybooru) | [![Travis CI](https://travis-ci.org/LuqueDaniel/pybooru.svg?branch=develop)](https://travis-ci.org/LuqueDaniel/pybooru) |
+| [Linux & OSX (Travis CI)](https://travis-ci.com/LuqueDaniel/pybooru) | [![Travis CI](https://travis-ci.com/LuqueDaniel/pybooru.svg?branch=master)](https://travis-ci.com/LuqueDaniel/pybooru) | [![Travis CI](https://travis-ci.com/LuqueDaniel/pybooru.svg?branch=develop)](https://travis-ci.com/LuqueDaniel/pybooru) |
 | [Windows (AppVeyor)](https://ci.appveyor.com/project/LuqueDaniel/pybooru) | [![AppVeyor](https://img.shields.io/appveyor/ci/luquedaniel/pybooru.svg)](https://ci.appveyor.com/project/LuqueDaniel/pybooru) | [![AppVeyor](https://img.shields.io/appveyor/ci/luquedaniel/pybooru/develop.svg)](https://ci.appveyor.com/project/LuqueDaniel/pybooru) |
 
 ## Contributing

--- a/changelog.md
+++ b/changelog.md
@@ -1,10 +1,20 @@
 # Pybooru - Changelog
 
-## Pybooru 4.2.0 - (unreleased)
+## Pybooru 4.2.0 - (2020-06-06)
 
-- Add support for Lolibooru
+**Note**: Pybooru 4.2.0 Is the last version that support Python 2.7
+
+- Add support for Lolibooru [#44](https://github.com/LuqueDaniel/pybooru/pull/44) by [@Nachtalb](https://github.com/Nachtalb)
+- Add support for safebooru.donmai.us to default sites [#37](https://github.com/LuqueDaniel/pybooru/pull/37) by [@mirukana](https://github.com/mirukana)
+- Add `count_posts()` function to Danbooru API [#35](https://github.com/LuqueDaniel/pybooru/pull/35) by [@mirukana](https://github.com/mirukana)
+- Replaced all `http` URLs for `https` [#36](https://github.com/LuqueDaniel/pybooru/pull/36) by [@mirukana](https://github.com/mirukana)
+- Fixes the file url in the download example [#39](https://github.com/LuqueDaniel/pybooru/pull/39) by [@Luk3M](https://github.com/Luk3M)
+- Fixes `Moebooru._build_hash_string`
+- Small refactors
+- Small fixes
 
 ## Pybooru 4.1.0 - (2017-02-08)
+
 - Pybooru: refactored `_get_status()`
 - Python 3.6 support
 - Fixed `PybooruHTTPError`
@@ -31,9 +41,11 @@
 - Documentation improvement
 
 ## Pybooru 4.0.1 - (2016/12/09)
+
 - Fix problems with Pypi
 
 ## Pybooru 4.0.0 - (2016/12/09)
+
 - Added support to Danbooru
 - Now Danbooru and Moebooru are two separed classes
 - Pybooru has been refactored
@@ -49,9 +61,11 @@
 - In this version there's a nice amount of improvements
 
 ## Pybooru 3.0.1 - (2015/01/13)
+
 - Minors changes
 
 ## Pybooru 3.0 - (2014/12/06)
+
 - In this version there's a nice amount of code improvements
 - Added compatibility with Python 3
 - Pybooru now use requests
@@ -60,9 +74,11 @@
 - Added Travis CI to the project
 
 ## Pybooru 2.1.1 - (2013/12/26)
+
 - Improve documentation style
 
 ## Pybooru 2.1 - (2013/10/14)
+
 - Added login suppport for any Moebooru based site
 - Fixed a bug: #c4b3435
 - Added new information to setup.py

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,9 +8,12 @@ Welcome to Pybooru's documentation!
 
 **Pybooru** is a Python package to access to the API of Danbooru/Moebooru based sites.
 
-- Version: **4.1.0**
+- Version: **4.2.0**
 - Licensed under: `MIT License <https://github.com/LuqueDaniel/pybooru/blob/master/LICENSE>`_
 - Python: >= 2.7 or Python: >= 3.3
+
+.. Note::
+  Pybooru 4.2.0 Is the last version that support Python 2.7
 
 Dependencies
 ------------

--- a/pybooru/__init__.py
+++ b/pybooru/__init__.py
@@ -17,7 +17,7 @@ Pybooru modules:
     resources -- Contains all resources for Pybooru.
 """
 
-__version__ = "4.2.0b1"
+__version__ = "4.2.0"
 __license__ = "MIT"
 __source_url__ = "https://github.com/LuqueDaniel/pybooru"
 __author__ = "Daniel Luque <danielluque14[at]gmail[dot]com>"


### PR DESCRIPTION
Many years later... 3 years and 4 month to be accurate, Pybooru get a new release. Thanks to all contributors. The next release, 5.0.0 It won't take so long to arrive.

**Note**: Pybooru 4.2.0 Is the last version that support Python 2.7

- Add support for Lolibooru [#44](https://github.com/LuqueDaniel/pybooru/pull/44) by [@Nachtalb](https://github.com/Nachtalb)
- Add support for safebooru.donmai.us to default sites [#37](https://github.com/LuqueDaniel/pybooru/pull/37) by [@mirukana](https://github.com/mirukana)
- Add `count_posts()` function to Danbooru API [#35](https://github.com/LuqueDaniel/pybooru/pull/35) by [@mirukana](https://github.com/mirukana)
- Replaced all `http` URLs for `https` [#36](https://github.com/LuqueDaniel/pybooru/pull/36) by [@mirukana](https://github.com/mirukana)
- Fixes the file url in the download example [#39](https://github.com/LuqueDaniel/pybooru/pull/39) by [@Luk3M](https://github.com/Luk3M)
- Fixes `Moebooru._build_hash_string`
- Small refactors
- Small fixes