### PR TITLE
Added 504 error to HTTP_STATUS_CODE in resources.py

### DIFF
--- a/pybooru/resources.py
+++ b/pybooru/resources.py
@@ -50,5 +50,6 @@ HTTP_STATUS_CODE = {
     423: ("Already Exists", "Resource already exists"),
     424: ("Invalid Parameters", "The given parameters were invalid"),
     500: ("Internal Server Error", "Some unknown error occurred on the server"),
-    503: ("Service Unavailable", "Server cannot currently handle the request")
+    503: ("Service Unavailable", "Server cannot currently handle the request"),
+    504: ("Gateway Timeout", "The server timed out while waiting for a response")
     }


### PR DESCRIPTION
## Description
I added a line for 504 server timeout errors to resources.py

## Motivation and Context
I was getting a KeyError from pybooru exceptions because danbooru was returning a 504, so I added a line to the HTTP_STATUS_CODE dictionary so that it can handle this error correctly.

## How Has This Been Tested?
I am currently running the version with this line changed in an app and I also ran the provisional_test.py (of course neither of these test for a 504 response but I'm not sure danbooru provides the capability to test for a 504 response so...)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project (PEP-8).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read CONTRIBUTING.md.
