### PR TITLE
chore: remove bdist_wheel from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,6 @@ classifiers =
     Topic :: Software Development :: Libraries :: Python Modules
     Topic :: Internet
     Topic :: Internet :: WWW/HTTP :: Site Management
-
 platforms = any
 long_description = file: README.md
 long_description_content_type = text/markdown; charset=UTF-8
@@ -45,6 +44,3 @@ docs =
     sphinx-rtd-theme
 all =
     %(docs)s
-
-[bdist_wheel]
-universal = 1


### PR DESCRIPTION
Since we will no longer support Py2.

Fixes #59