### PR TITLE
dev(narugo): add limit and page for tag_list API

### DIFF
--- a/pybooru/api_danbooru.py
+++ b/pybooru/api_danbooru.py
@@ -11,6 +11,8 @@ Classes:
 # __future__ imports
 from __future__ import absolute_import
 
+import warnings
+
 # pybooru imports
 from .exceptions import PybooruAPIError
 
@@ -988,7 +990,7 @@ class DanbooruApi_Mixin(object):
         return self._get('pool_versions.json', params)
 
     def tag_list(self, name_matches=None, name=None, category=None,
-                 hide_empty=None, has_wiki=None, has_artist=None, order=None):
+                 hide_empty=None, has_wiki=None, has_artist=None, order=None, limit=1000, page=1):
         """Get a list of tags.
 
         Parameters:
@@ -1004,7 +1006,11 @@ class DanbooruApi_Mixin(object):
             has_wiki (str): Can be: yes, no.
             has_artist (str): Can be: yes, no.
             order (str): Can be: name, date, count.
+            limit (int): Limit of one page, no more than 1000.
+            page (int): Page.
         """
+        if limit > 1000:
+            warnings.warn(UserWarning(f'Limit over 1000 is not supported by API, but {limit!r} found.'), stacklevel=2)
         params = {
             'search[name_matches]': name_matches,
             'search[name]': name,
@@ -1012,7 +1018,9 @@ class DanbooruApi_Mixin(object):
             'search[hide_empty]': hide_empty,
             'search[has_wiki]': has_wiki,
             'search[has_artist]': has_artist,
-            'search[order]': order
+            'search[order]': order,
+            'limit': str(limit),
+            'page': str(page),
             }
         return self._get('tags.json', params)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add `limit` and `page` for `tag_list` API.

More details of API can be found in following pages:
* https://danbooru.donmai.us/wiki_pages/api%3Atags
* https://danbooru.donmai.us/wiki_pages/help%3Aapi_read_requests
* https://danbooru.donmai.us/wiki_pages/help%3Ahash_syntax

## Motivation and Context

Only 20 tags will be returned when `limit` is not specified. This will be terrible when you need to crawl plenty of tags from danbooru.

## How Has This Been Tested?

Tested with the code in example part.

## Code Examples (if appropriate):

```python
from pybooru import Danbooru

client = Danbooru('danbooru')
tags = client.tag_list(name_matches='*_(arknights)', category="4", hide_empty="yes")
for i, t in enumerate(tags):
    print(i, t['id'], t['name'])
```

The output should contain about 750 lines of text, each containing a tag.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project (PEP-8).
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have readed CONTRIBUTING.md.
